### PR TITLE
Update firebird.inc.php

### DIFF
--- a/inc/firebird.inc.php
+++ b/inc/firebird.inc.php
@@ -170,7 +170,6 @@ function get_reserved_words($server_family, $server_version) {
     }
 
     return $reserved_words;
-}
 
 
 //
@@ -184,7 +183,6 @@ function get_context_variables($server_family, $server_version) {
     }
 
     return $context_variables;
-}
 
 
 //


### PR DESCRIPTION
FastCGI sent in stderr: "PHP message: PHP Parse error:  syntax error, unexpected '}' firebirdwebadmin/inc/firebird.inc.php on line 173" while reading response header from upstream, client: xxx.xxx.xxx.xxx, server: hostname.com, request: "GET /firebirdwebadmin/database.php HTTP/1.1", upstream: "fastcgi://unix:/var/run/php5-fpm.sock:", host: "hostname.com"
