### PR TITLE
Don't warn if "isql" is "isql-fb" on Linux

### DIFF
--- a/inc/script_start.inc.php
+++ b/inc/script_start.inc.php
@@ -89,7 +89,7 @@ if ($s_binpath != BINPATH) {
 
     // check the availabillity of the isql binary
     if (!is_dir(BINPATH)
-        || (!is_file(BINPATH.'isql') && !is_file(BINPATH.'isql.exe'))
+        || (!is_file(BINPATH.'isql') && !is_file(BINPATH.'isql-fb') && !is_file(BINPATH.'isql.exe'))
     ) {
         $warning = sprintf($WARNINGS['BAD_ISQLPATH'], BINPATH);
     }


### PR DESCRIPTION
Don't warn if "isql" is "isql-fb" on Linux (code anyway uses "isql-fb" internally)